### PR TITLE
Use byte_strings crate.

### DIFF
--- a/demo-app/Cargo.lock
+++ b/demo-app/Cargo.lock
@@ -83,6 +83,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "byte-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "002ee5531feb8450e59862fefa550eeac39b726d60b186071672751045ebc29a"
+dependencies = [
+ "byte-strings-proc_macros",
+]
+
+[[package]]
+name = "byte-strings-proc_macros"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f7e0e71f98d6c71bfe42b0a7a47d0f870ad808401fad2d44fa156ed5b0ae03"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +246,7 @@ dependencies = [
 name = "demo-app"
 version = "0.0.0"
 dependencies = [
+ "byte-strings",
  "cc",
  "cortex-m",
  "cortex-m-rt",

--- a/demo-app/Cargo.toml
+++ b/demo-app/Cargo.toml
@@ -18,6 +18,7 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 defmt = "0.3.5"
 defmt-rtt = "0.4"
 threadx-sys = { path = "../threadx-sys" }
+byte-strings = "0.3.1"
 
 # optimize code in both profiles
 [profile.dev]

--- a/demo-app/src/main.rs
+++ b/demo-app/src/main.rs
@@ -6,8 +6,9 @@
 #![no_main]
 #![no_std]
 
-use core::{ffi::CStr, mem::MaybeUninit};
+use core::mem::MaybeUninit;
 
+use byte_strings::c;
 use cortex_m_rt::entry;
 use defmt_rtt as _;
 use nrf52840_hal::prelude::OutputPin;
@@ -20,11 +21,8 @@ const DEMO_STACK_SIZE: usize = 1024;
 #[no_mangle]
 extern "C" fn tx_application_define(_first_unused_memory: *mut core::ffi::c_void) {
     static mut THREAD0: MaybeUninit<threadx_sys::TX_THREAD> = MaybeUninit::uninit();
-    const THREAD0_NAME: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"thread0\0") };
     static mut THREAD1: MaybeUninit<threadx_sys::TX_THREAD> = MaybeUninit::uninit();
-    const THREAD1_NAME: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"thread1\0") };
     static mut BYTE_POOL: MaybeUninit<threadx_sys::TX_BYTE_POOL> = MaybeUninit::uninit();
-    const BYTE_POOL_NAME: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"byte-pool0\0") };
     static mut BYTE_POOL_STORAGE: MaybeUninit<[u8; 32768]> = MaybeUninit::uninit();
 
     defmt::println!("In tx_application_define()...");
@@ -34,7 +32,7 @@ extern "C" fn tx_application_define(_first_unused_memory: *mut core::ffi::c_void
     unsafe {
         threadx_sys::_tx_byte_pool_create(
             BYTE_POOL.as_mut_ptr(),
-            BYTE_POOL_NAME.as_ptr() as *mut threadx_sys::CHAR,
+            c!("byte-pool0").as_ptr() as *mut threadx_sys::CHAR,
             BYTE_POOL_STORAGE.as_mut_ptr() as *mut _,
             core::mem::size_of_val(&BYTE_POOL_STORAGE) as u32,
         );
@@ -48,7 +46,7 @@ extern "C" fn tx_application_define(_first_unused_memory: *mut core::ffi::c_void
         defmt::println!("Stack allocated @ {:08x}", pointer);
         threadx_sys::_tx_thread_create(
             THREAD0.as_mut_ptr(),
-            THREAD0_NAME.as_ptr() as *mut threadx_sys::CHAR,
+            c!("thread0").as_ptr() as *mut threadx_sys::CHAR,
             Some(my_thread),
             0x12345678,
             pointer,
@@ -70,7 +68,7 @@ extern "C" fn tx_application_define(_first_unused_memory: *mut core::ffi::c_void
         defmt::println!("Stack allocated @ {:08x}", pointer);
         threadx_sys::_tx_thread_create(
             THREAD1.as_mut_ptr(),
-            THREAD1_NAME.as_ptr() as *mut threadx_sys::CHAR,
+            c!("thread1").as_ptr() as *mut threadx_sys::CHAR,
             Some(my_thread),
             0xAABBCCDD,
             pointer,


### PR DESCRIPTION
Use the `byte_strings::c!` macro to ensure strings are null-terminated.

Will replace with c"Hello" strings in around Rust 1.77.